### PR TITLE
Install procps-ng in the container

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -10,5 +10,7 @@ FROM registry.access.redhat.com/ubi9-minimal:9.6-1755695350
 LABEL org.opencontainers.image.source="https://github.com/InHolland-Cloud-Minor-2526/ubi9-okd-tools" \
       org.opencontainers.image.description="Let's run a okd oc client in a container"
 
+RUN microdnf install -y procps-ng && microdnf clean all
+
 COPY --from=build /usr/local/bin/* /usr/local/bin/
 COPY kubeconform /usr/local/share/kubeconform/


### PR DESCRIPTION
To enable `watch oc get [...]` in the container.